### PR TITLE
Various bugfixes introduced by using json-based parsing

### DIFF
--- a/src/main/scala/com/c4soft/sbtavro/utils/SchemaParser.scala
+++ b/src/main/scala/com/c4soft/sbtavro/utils/SchemaParser.scala
@@ -33,7 +33,10 @@ class SchemaParser(fromFile: File) {
       case obj: JsObject =>
         obj \ "type" match {
           case JsArray(values) => values.flatMap(v => extractTypes(v))
-          case JsString("record") => parseFields((obj \ "fields").as[JsArray])
+          case JsString("record") => (obj \ "fields").as[JsArray].value.flatMap {
+            case obj: JsObject => extractTypes(obj)
+            case _ => Seq.empty
+          }
           case JsString("array") => extractTypes(obj \ "items")
           case JsString(otherType) => Seq(otherType)
           case obj: JsObject => extractTypes(obj)
@@ -41,13 +44,6 @@ class SchemaParser(fromFile: File) {
         }
       case JsArray(values) => values.flatMap(v => extractTypes(v))
       case other => Seq.empty
-    }
-  }
-
-  private def parseFields(listOfFields: JsArray) = {
-    listOfFields.value.flatMap {
-      case obj: JsObject => extractTypes(obj)
-      case _ => Seq.empty
     }
   }
 

--- a/src/main/scala/com/c4soft/sbtavro/utils/SchemaParser.scala
+++ b/src/main/scala/com/c4soft/sbtavro/utils/SchemaParser.scala
@@ -16,33 +16,43 @@ class SchemaParser(fromFile: File) {
 
   // needs to be lazy so it's initialized after the enum values
   private lazy val avroDefaultTypeNames = Schema.Type.values().map(_.getName)
+  private lazy val namespaceOpt = (jsonValue \ "namespace").asOpt[String]
 
-  def getFullyQualifiedName(): String = {
-    val namespaceOpt = (jsonValue \ "namespace").asOpt[String]
-    val name = (jsonValue \ "name").as[String]
+  def getFullyQualifiedName(name: String = (jsonValue \ "name").as[String]): String = {
     namespaceOpt.map(_ + ".").getOrElse("") + name
   }
 
-  def getDependentSchemas(typeExclusions: Seq[String] = avroDefaultTypeNames): Seq[String] = {
-    extractTypes(jsonValue).filterNot(typeExclusions.contains).distinct
+  def getDeclaredSchemas(typeExclusions: Seq[String] = avroDefaultTypeNames): Seq[String] = {
+    extractTypes(jsonValue, declaredSchemas = true).filterNot(typeExclusions.contains).distinct
   }
 
-  private def extractTypes(value: JsValue): Seq[String] = {
+  def getDependentSchemas(typeExclusions: Seq[String] = avroDefaultTypeNames): Seq[String] = {
+    extractTypes(jsonValue, declaredSchemas = false).filterNot(typeExclusions.contains).distinct
+  }
+
+  private def extractTypes(value: JsValue, declaredSchemas: Boolean): Seq[String] = {
     value match {
-      case JsString(_type) => Seq(_type)
+      case JsString(_type) if !declaredSchemas => Seq(_type)
       case obj: JsObject =>
         obj \ "type" match {
-          case JsArray(values) => values.flatMap(v => extractTypes(v))
-          case JsString("record") => (obj \ "fields").as[JsArray].value.flatMap {
-            case obj: JsObject => extractTypes(obj)
-            case _ => Seq.empty
-          }
-          case JsString("array") => extractTypes(obj \ "items")
-          case JsString(otherType) => Seq(otherType)
-          case obj: JsObject => extractTypes(obj)
+          case JsArray(values) => values.flatMap(v => extractTypes(v, declaredSchemas))
+          case JsString("record") =>
+            val fromRecordName = (obj \ "name").asOpt[String].filter(_ => declaredSchemas) match {
+              case Some(name) => Seq(getFullyQualifiedName(name))
+              case None => Seq.empty
+            }
+            val fromRecordFields = (obj \ "fields").as[JsArray].value.flatMap {
+              case obj: JsObject => extractTypes(obj, declaredSchemas)
+              case _ => Seq.empty
+            }
+
+            fromRecordName ++ fromRecordFields
+          case JsString("array") => extractTypes(obj \ "items", declaredSchemas)
+          case JsString(otherType) if !declaredSchemas => Seq(otherType)
+          case obj: JsObject => extractTypes(obj, declaredSchemas)
           case _ => Seq.empty
         }
-      case JsArray(values) => values.flatMap(v => extractTypes(v))
+      case JsArray(values) => values.flatMap(v => extractTypes(v, declaredSchemas))
       case other => Seq.empty
     }
   }

--- a/src/main/scala/com/c4soft/sbtavro/utils/SchemaParser.scala
+++ b/src/main/scala/com/c4soft/sbtavro/utils/SchemaParser.scala
@@ -34,10 +34,12 @@ class SchemaParser(fromFile: File) {
         obj \ "type" match {
           case JsArray(values) => values.flatMap(v => extractTypes(v))
           case JsString("record") => parseFields((obj \ "fields").as[JsArray])
+          case JsString("array") => extractTypes(obj \ "items")
           case JsString(otherType) => Seq(otherType)
           case obj: JsObject => extractTypes(obj)
           case _ => Seq.empty
         }
+      case JsArray(values) => values.flatMap(v => extractTypes(v))
       case other => Seq.empty
     }
   }

--- a/src/test/resources/avro/RecordReferencingItsOwnTypes.avsc
+++ b/src/test/resources/avro/RecordReferencingItsOwnTypes.avsc
@@ -1,0 +1,18 @@
+{
+  "name": "RecordReferencingItself",
+  "type": "record",
+  "fields": [{
+    "name": "InlinedRecord",
+    "type": "record",
+    "fields": [{
+        "name": "field1",
+        "type": "string"
+    }, {
+        "name": "field2",
+        "type": "long"
+    }]
+   }, {
+    "name": "ReferencingItself",
+    "type": ["null", "InlinedRecord"]
+   }]
+}

--- a/src/test/resources/avro/RecordWithArray.avsc
+++ b/src/test/resources/avro/RecordWithArray.avsc
@@ -1,0 +1,18 @@
+{
+    "type": "record",
+    "namespace": "com.c4soft.sbtavro",
+    "name": "RecordWithArray",
+    "fields": [{
+            "name": "foo",
+            "type": "array",
+            "items": ["null", "TypeWithinArray"]
+        }, {
+            "name": "bar",
+            "type": "string"
+        }, {
+            "name": "baz",
+            "type": "array",
+            "items": "string"
+        }
+    ]
+}

--- a/src/test/scala/com/c4soft/sbtavro/SbtAvroSpec.scala
+++ b/src/test/scala/com/c4soft/sbtavro/SbtAvroSpec.scala
@@ -43,4 +43,8 @@ class SbtAvroSpec extends Specification with Mockito {
     bJavaFile.isFile must beTrue
     cJavaFile.isFile must beTrue
   }
+
+  "SortSchemaFiles should not crash when a schema is referencing one of its inlined types" >> {
+    SbtAvro.sortSchemaFiles(Seq(new File(sourceDir, "RecordReferencingItsOwnTypes.avsc")), mock[Logger]) must not(throwA[NoSuchElementException])
+  }
 }

--- a/src/test/scala/com/c4soft/sbtavro/utils/SchemaParserSpec.scala
+++ b/src/test/scala/com/c4soft/sbtavro/utils/SchemaParserSpec.scala
@@ -19,4 +19,9 @@ class SchemaParserSpec extends Specification {
   "SchemaParser should correctly ignore certain types when getting the dependent schemas" >> {
     parser.getDependentSchemas(Seq("com.c4soft.sbtavro.SchemaParsing2")) must containTheSameElementsAs(Seq("com.c4soft.sbtavro.SchemaParsing1"))
   }
+  "SchemaParser should be able to find dependant type inside of arrays" >> {
+    val fileWithArray = new File(getClass.getClassLoader.getResource("avro/RecordWithArray.avsc").toURI)
+    val newParser = new SchemaParser(fileWithArray)
+    newParser.getDependentSchemas() must containTheSameElementsAs(Seq("TypeWithinArray"))
+  }
 }


### PR DESCRIPTION
Replacing regex-based schema parsing with json-based parsing introduced a few bugs by not covering some special cases:
- Dependant schemas can be declared inside of arrays (eg. when a field is nullable there are multiple types declared)
- A Schema can both declare a sub-type and reference it later in the the same avro file
